### PR TITLE
HSDEV-5957 - should not return partial segments that start before the timeshiftbuffer 

### DIFF
--- a/src/segment/durationTimeParser.js
+++ b/src/segment/durationTimeParser.js
@@ -73,7 +73,8 @@ export const segmentRange = {
       duration,
       periodStart = 0,
       minimumUpdatePeriod = 0,
-      timeShiftBufferDepth = Infinity
+      timeShiftBufferDepth = Infinity,
+      timeShiftBufferDepthMargin = 0
     } = attributes;
     const endNumber = parseEndNumber(attributes.endNumber);
     // clientOffset is passed in at the top level of mpd-parser and is an offset calculated
@@ -87,7 +88,7 @@ export const segmentRange = {
     const periodDuration = periodEndWC - periodStartWC;
     const segmentCount = Math.ceil(periodDuration * timescale / duration);
     const availableStart =
-      Math.floor((now - periodStartWC - timeShiftBufferDepth) * timescale / duration);
+      Math.floor((now - periodStartWC - timeShiftBufferDepth + timeShiftBufferDepthMargin) * timescale / duration);
     const availableEnd = Math.floor((now - periodStartWC) * timescale / duration);
 
     return {

--- a/src/toM3u8.js
+++ b/src/toM3u8.js
@@ -496,6 +496,9 @@ export const toM3u8 = ({
   if (timeShiftBufferDepth) {
     manifest.timeShiftBufferDepth = timeShiftBufferDepth;
   }
+  if (timeShiftBufferDepth && options && options.timeShiftBufferDepthMargin) {
+    manifest.timeShiftBufferDepthMargin = options.timeShiftBufferDepthMargin;
+  }
 
   if (publishTime) {
     manifest.publishTime = new Date(publishTime).toISOString();

--- a/src/toPlaylists.js
+++ b/src/toPlaylists.js
@@ -33,6 +33,9 @@ export const generateSegments = ({ attributes, segmentInfo }, options) => {
   if (segmentAttributes.codecs === 'stpp' && options.removeSubtitlesInit) {
     segmentAttributes.removeInitMap = true;
   }
+  if (options && options.timeShiftBufferDepthMargin) {
+    segmentAttributes.timeShiftBufferDepthMargin = options.timeShiftBufferDepthMargin;
+  }
   const segments = segmentsFn(segmentAttributes, segmentInfo.segmentTimeline);
 
   // The @duration attribute will be used to determin the playlist's targetDuration which

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,6 @@
 import { parse, VERSION } from '../src';
 import QUnit from 'qunit';
+import { useFakeTimers } from 'sinon';
 
 QUnit.dump.maxDepth = Infinity;
 
@@ -21,6 +22,7 @@ import multiperiodDynamic from './manifests/multiperiod-dynamic.mpd';
 import audioOnly from './manifests/audio-only.mpd';
 import trickMode from './manifests/trickmode.mpd';
 import multiperiodStartnumber from './manifests/multiperiod-startnumber.mpd';
+import dynamicTimeShiftBufferDepthMargin from './manifests/dynamic-timeshiftbufferdepth-margin.mpd';
 import multiperiodStartnumberRemovedPeriods from
   './manifests/multiperiod-startnumber-removed-periods.mpd';
 import stppNoInit from './manifests/stpp-no-init.mpd';
@@ -84,6 +86,9 @@ import {
 import {
   parsedManifest as multiperiodStartnumberManifest
 } from './manifests/multiperiod-startnumber.js';
+import {
+  parsedManifest as dynamicManifestTimeShiftBufferDepthMargin
+} from './manifests/dynamic-timeshiftbufferdepth-margin.js';
 import {
   parsedManifest as multiperiodStartnumberRemovedPeriodsManifest
 } from './manifests/multiperiod-startnumber-removed-periods.js';
@@ -197,9 +202,20 @@ QUnit.test('has parse', function(assert) {
   input: multiperiodoverlapped,
   expected: multiperiodOverlappedNoPeriodMergeManifest,
   options: { mergePeriods: false }
+}, {
+  // test will use the sinon mock to simulate NOW
+  // original MPD has 64s of segments.
+  // using margin:10 we expect to get 56s of segments.
+  name: 'dynamic_with_timeshiftBufferDepthMargin',
+  input: dynamicTimeShiftBufferDepthMargin,
+  expected: dynamicManifestTimeShiftBufferDepthMargin,
+  options: { timeShiftBufferDepthMargin: 10 }
 }].forEach(({ name, input, expected, options = {} }) => {
   QUnit.test(`${name} test manifest`, function(assert) {
+    const clock = useFakeTimers(new Date('2023-07-09T12:34:56Z'));
     const actual = parse(input, options);
+
+    clock.restore();
 
     assert.deepEqual(actual, expected);
   });

--- a/test/manifests/dynamic-timeshiftbufferdepth-margin.js
+++ b/test/manifests/dynamic-timeshiftbufferdepth-margin.js
@@ -1,0 +1,263 @@
+export const parsedManifest = {
+  allowCache: true,
+  discontinuityStarts: [],
+  duration: 0,
+  endList: false,
+  mediaGroups: {
+    'AUDIO': {
+      audio: {
+        en: {
+          autoselect: true,
+          default: true,
+          language: 'en',
+          playlists: [
+            {
+              attributes: {
+                'BANDWIDTH': 36997,
+                'CODECS': 'mp4a.40.2',
+                'NAME': 'A48',
+                'PROGRAM-ID': 1
+              },
+              discontinuitySequence: 0,
+              discontinuityStarts: [],
+              endList: false,
+              mediaSequence: 0,
+              resolvedUri: '',
+              segments: [
+                {
+                  duration: 8,
+                  map: {
+                    resolvedUri: 'http://example.com/A48/init.mp4',
+                    uri: 'A48/init.mp4'
+                  },
+                  number: 0,
+                  presentationTime: 1688906040,
+                  resolvedUri: 'http://example.com/A48/211113255.m4s',
+                  timeline: 0,
+                  uri: 'A48/211113255.m4s'
+                },
+                {
+                  duration: 8,
+                  map: {
+                    resolvedUri: 'http://example.com/A48/init.mp4',
+                    uri: 'A48/init.mp4'
+                  },
+                  number: 1,
+                  presentationTime: 1688906048,
+                  resolvedUri: 'http://example.com/A48/211113256.m4s',
+                  timeline: 0,
+                  uri: 'A48/211113256.m4s'
+                },
+                {
+                  duration: 8,
+                  map: {
+                    resolvedUri: 'http://example.com/A48/init.mp4',
+                    uri: 'A48/init.mp4'
+                  },
+                  number: 2,
+                  presentationTime: 1688906056,
+                  resolvedUri: 'http://example.com/A48/211113257.m4s',
+                  timeline: 0,
+                  uri: 'A48/211113257.m4s'
+                },
+                {
+                  duration: 8,
+                  map: {
+                    resolvedUri: 'http://example.com/A48/init.mp4',
+                    uri: 'A48/init.mp4'
+                  },
+                  number: 3,
+                  presentationTime: 1688906064,
+                  resolvedUri: 'http://example.com/A48/211113258.m4s',
+                  timeline: 0,
+                  uri: 'A48/211113258.m4s'
+                },
+                {
+                  duration: 8,
+                  map: {
+                    resolvedUri: 'http://example.com/A48/init.mp4',
+                    uri: 'A48/init.mp4'
+                  },
+                  number: 4,
+                  presentationTime: 1688906072,
+                  resolvedUri: 'http://example.com/A48/211113259.m4s',
+                  timeline: 0,
+                  uri: 'A48/211113259.m4s'
+                },
+                {
+                  duration: 8,
+                  map: {
+                    resolvedUri: 'http://example.com/A48/init.mp4',
+                    uri: 'A48/init.mp4'
+                  },
+                  number: 5,
+                  presentationTime: 1688906080,
+                  resolvedUri: 'http://example.com/A48/211113260.m4s',
+                  timeline: 0,
+                  uri: 'A48/211113260.m4s'
+                },
+                {
+                  duration: 8,
+                  last: true,
+                  map: {
+                    resolvedUri: 'http://example.com/A48/init.mp4',
+                    uri: 'A48/init.mp4'
+                  },
+                  number: 6,
+                  presentationTime: 1688906088,
+                  resolvedUri: 'http://example.com/A48/211113261.m4s',
+                  timeline: 0,
+                  uri: 'A48/211113261.m4s'
+                }
+              ],
+              targetDuration: 8,
+              timeline: 0,
+              timelineStarts: [
+                {
+                  start: 0,
+                  timeline: 0
+                }
+              ],
+              uri: ''
+            }
+          ],
+          uri: ''
+        }
+      }
+    },
+    'CLOSED-CAPTIONS': {},
+    'SUBTITLES': {},
+    'VIDEO': {}
+  },
+  minimumUpdatePeriod: 3153600000000,
+  playlists: [
+    {
+      attributes: {
+        'AUDIO': 'audio',
+        'BANDWIDTH': 303780,
+        'CODECS': 'avc1.64001e',
+        'FRAME-RATE': 30,
+        'NAME': 'V300',
+        'PROGRAM-ID': 1,
+        'RESOLUTION': {
+          height: 360,
+          width: 640
+        },
+        'SUBTITLES': 'subs'
+      },
+      discontinuitySequence: 0,
+      discontinuityStarts: [],
+      endList: false,
+      mediaSequence: 0,
+      resolvedUri: '',
+      segments: [
+        {
+          duration: 8,
+          map: {
+            resolvedUri: 'http://example.com/V300/init.mp4',
+            uri: 'V300/init.mp4'
+          },
+          number: 0,
+          presentationTime: 1688906040,
+          resolvedUri: 'http://example.com/V300/211113255.m4s',
+          timeline: 0,
+          uri: 'V300/211113255.m4s'
+        },
+        {
+          duration: 8,
+          map: {
+            resolvedUri: 'http://example.com/V300/init.mp4',
+            uri: 'V300/init.mp4'
+          },
+          number: 1,
+          presentationTime: 1688906048,
+          resolvedUri: 'http://example.com/V300/211113256.m4s',
+          timeline: 0,
+          uri: 'V300/211113256.m4s'
+        },
+        {
+          duration: 8,
+          map: {
+            resolvedUri: 'http://example.com/V300/init.mp4',
+            uri: 'V300/init.mp4'
+          },
+          number: 2,
+          presentationTime: 1688906056,
+          resolvedUri: 'http://example.com/V300/211113257.m4s',
+          timeline: 0,
+          uri: 'V300/211113257.m4s'
+        },
+        {
+          duration: 8,
+          map: {
+            resolvedUri: 'http://example.com/V300/init.mp4',
+            uri: 'V300/init.mp4'
+          },
+          number: 3,
+          presentationTime: 1688906064,
+          resolvedUri: 'http://example.com/V300/211113258.m4s',
+          timeline: 0,
+          uri: 'V300/211113258.m4s'
+        },
+        {
+          duration: 8,
+          map: {
+            resolvedUri: 'http://example.com/V300/init.mp4',
+            uri: 'V300/init.mp4'
+          },
+          number: 4,
+          presentationTime: 1688906072,
+          resolvedUri: 'http://example.com/V300/211113259.m4s',
+          timeline: 0,
+          uri: 'V300/211113259.m4s'
+        },
+        {
+          duration: 8,
+          map: {
+            resolvedUri: 'http://example.com/V300/init.mp4',
+            uri: 'V300/init.mp4'
+          },
+          number: 5,
+          presentationTime: 1688906080,
+          resolvedUri: 'http://example.com/V300/211113260.m4s',
+          timeline: 0,
+          uri: 'V300/211113260.m4s'
+        },
+        {
+          duration: 8,
+          last: true,
+          map: {
+            resolvedUri: 'http://example.com/V300/init.mp4',
+            uri: 'V300/init.mp4'
+          },
+          number: 6,
+          presentationTime: 1688906088,
+          resolvedUri: 'http://example.com/V300/211113261.m4s',
+          timeline: 0,
+          uri: 'V300/211113261.m4s'
+        }
+      ],
+      targetDuration: 8,
+      timeline: 0,
+      timelineStarts: [
+        {
+          start: 0,
+          timeline: 0
+        }
+      ],
+      uri: ''
+    }
+  ],
+  publishTime: '2023-07-09T06:38:25.000Z',
+  segments: [],
+  suggestedPresentationDelay: undefined,
+  timeShiftBufferDepth: 64,
+  timeShiftBufferDepthMargin: 10,
+  timelineStarts: [
+    {
+      start: 0,
+      timeline: 0
+    }
+  ],
+  uri: ''
+};

--- a/test/manifests/dynamic-timeshiftbufferdepth-margin.mpd
+++ b/test/manifests/dynamic-timeshiftbufferdepth-margin.mpd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?" maxSegmentDuration="PT8S" minBufferTime="PT1S" minimumUpdatePeriod="P100Y" profiles="urn:mpeg:dash:profile:full:2011,http://www.dashif.org/guidelines/low-latency-live-v5" publishTime="2023-07-09T06:38:25Z" timeShiftBufferDepth="PT1M4S" type="dynamic">
+  <BaseURL>http://example.com/</BaseURL>
+  <Period id="p0" start="PT0S">
+    <AdaptationSet contentType="audio" lang="en" segmentAlignment="true">
+      <SegmentTemplate availabilityTimeComplete="false" availabilityTimeOffset="7.000000" duration="384000" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" timescale="48000" />
+      <Representation audioSamplingRate="48000" bandwidth="36997" codecs="mp4a.40.2" id="A48" mimeType="audio/mp4" startWithSAP="1">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet contentType="video" maxFrameRate="30" maxHeight="720" maxWidth="1280" par="16:9" segmentAlignment="true">
+      <SegmentTemplate availabilityTimeComplete="false" availabilityTimeOffset="7.000000" duration="122880" initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Number$.m4s" startNumber="0" timescale="15360" />
+      <Representation bandwidth="303780" codecs="avc1.64001e" frameRate="30" height="360" id="V300" mimeType="video/mp4" sar="1:1" startWithSAP="1" width="640" />
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
@shlompy 

period start will be:
```
    const availableStart =
      Math.floor((now - periodStartWC - timeShiftBufferDepth + timeShiftBufferDepthMargin) * timescale / duration);
```

so it till now window range was:
`[now-timeShiftBufferDepth: now-suggestedPresentationDelay] `
it now will be:
`[now-timeShiftBufferDepth+timeShiftBufferDepthMargin: now-suggestedPresentationDelay]`

e.g:
for 
```
timeShiftBufferDepth: 5m
suggestedPresentationDelay: 8s
timeShiftBufferDepthMargin: 10s
```
`[now-5m:now-8s]` >> `[now-4m50s:now-8s]`
